### PR TITLE
[#33] body 태그에 먹힌 css 제거

### DIFF
--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -2,8 +2,6 @@ import { useLocation } from "react-router-dom";
 import Login from "./login/Login";
 import Signup from "./signup/Signup";
 
-import "./users.scss";
-
 const Users = () => {
 
   const location = useLocation();

--- a/src/pages/users/login/Login.tsx
+++ b/src/pages/users/login/Login.tsx
@@ -1,11 +1,10 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import CommonButton from "../../../components/commonButton/CommonButton"
+import { CommonButton } from "@/src/components";
 import { FaRegEye } from "react-icons/fa";
 import { FaRegEyeSlash } from "react-icons/fa";
 
 import "../users.scss";
-
 
 const Login = () => {
 
@@ -24,44 +23,46 @@ const Login = () => {
 
   return (
     <>
-      <div className="bg-wrap">
-        <div className="login-wrap">
-          <ul className="login-wrap__header">
-            <li className="header-list">
-              <a className="link on">로그인</a>
-            </li>
-            <li className="header-list">
-              <a className="link" 
-              onClick={goToSignUp}>회원가입</a>
-            </li>
-          </ul> 
-          <form action="">
-            <div className="login-wrap__body">
-              <div className="input-inner">
-                <label htmlFor="">아이디</label>
-                <input type="text" placeholder="아이디를 입력해주세요" />
+      <div className="user-wrap">
+        <div className="bg-wrap">
+          <div className="login-wrap">
+            <ul className="login-wrap__header">
+              <li className="header-list">
+                <a className="link on">로그인</a>
+              </li>
+              <li className="header-list">
+                <a className="link" 
+                onClick={goToSignUp}>회원가입</a>
+              </li>
+            </ul> 
+            <form action="">
+              <div className="login-wrap__body">
+                <div className="input-inner">
+                  <label htmlFor="">아이디</label>
+                  <input type="text" placeholder="아이디를 입력해주세요" />
+                </div>
+                <div className="input-inner">
+                <label htmlFor="">비밀번호</label>
+                <div className="input-inner__item">
+                  <input
+                    placeholder="비밀번호를 입력해주세요"
+                    type={isPwVisible ? "text" : "password"}
+                  />
+                  <button type="button"
+                    className="btn-visible"
+                    onClick={() => togglePw()}
+                  >
+                    {isPwVisible ? <FaRegEyeSlash /> : <FaRegEye />}
+                  </button>
+                </div>
               </div>
-              <div className="input-inner">
-              <label htmlFor="">비밀번호</label>
-              <div className="input-inner__item">
-                <input
-                  placeholder="비밀번호를 입력해주세요"
-                  type={isPwVisible ? "text" : "password"}
+                <CommonButton
+                text={'로그인'}
+                buttonSize={'large'}
                 />
-                <button type="button"
-                  className="btn-visible"
-                  onClick={() => togglePw()}
-                >
-                  {isPwVisible ? <FaRegEyeSlash /> : <FaRegEye />}
-                </button>
               </div>
-            </div>
-              <CommonButton
-              text={'로그인'}
-              buttonSize={'large'}
-              />
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
       </div>
     </>

--- a/src/pages/users/signup/Signup.tsx
+++ b/src/pages/users/signup/Signup.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import TermsAgreement from "@/src/components/termsAgreement/TermsAgreement";
+import { CommonButton } from "@/src/components";
 import { FaRegEye } from "react-icons/fa";
 import { FaRegEyeSlash } from "react-icons/fa";
 
 import "../users.scss";
-import TermsAgreement from "@/src/components/termsAgreement/TermsAgreement";
-import { CommonButton } from "@/src/components";
 
 const Signup = () => {
 
@@ -29,79 +29,81 @@ const Signup = () => {
 
   return (
     <>
-      <div className='bg-wrap'>
-        <div className="login-wrap">
-          <ul className="login-wrap__header">
-            <li className="header-list">
-              <a href="" className="link" onClick={goToLogin}>로그인</a>
-            </li>
-            <li className="header-list">
-              <a href="" className="link on">회원가입</a>
-            </li>
-          </ul> 
-          <form action="">
-            <div className="login-wrap__body">
-            <div className="input-inner">
-              <label htmlFor="">이름</label>
-              <input type="text" placeholder="이름을 입력해주세요" />
-            </div>
-            <div className="input-inner">
-              <label htmlFor="">아이디</label>
-              <div className="input-inner__item">
-                <input type="text" placeholder="아이디를 입력해주세요" />
-                <button className="btn-check">중복확인</button>
+      <div className="user-wrap">
+        <div className="bg-wrap">
+          <div className="login-wrap">
+            <ul className="login-wrap__header">
+              <li className="header-list">
+                <a href="" className="link" onClick={goToLogin}>로그인</a>
+              </li>
+              <li className="header-list">
+                <a href="" className="link on">회원가입</a>
+              </li>
+            </ul> 
+            <form action="">
+              <div className="login-wrap__body">
+              <div className="input-inner">
+                <label htmlFor="">이름</label>
+                <input type="text" placeholder="이름을 입력해주세요" />
               </div>
-            </div>
-            <div className="input-inner">
-              <label htmlFor="">닉네임</label>
-              <div className="input-inner__item">
-                <input type="text" placeholder="닉네임을 입력해주세요" />
-                <button className="btn-check">중복확인</button>
+              <div className="input-inner">
+                <label htmlFor="">아이디</label>
+                <div className="input-inner__item">
+                  <input type="text" placeholder="아이디를 입력해주세요" />
+                  <button className="btn-check">중복확인</button>
+                </div>
               </div>
-            </div>
-            <div className="input-inner">
-              <label htmlFor="">휴대폰 번호</label>
-              <input type="text" placeholder="숫자만 입력해주세요" />
-            </div>
-            <div className="input-inner">
-              <label htmlFor="">비밀번호</label>
-              <div className="input-inner__item">
-                <input
-                  placeholder="비밀번호를 입력해주세요"
-                  type={isPwVisible ? "text" : "password"}
-                />
-                <button type="button"
-                  className="btn-visible"
-                  onClick={() => togglePw('password')}
-                >
-                  {isPwVisible ? <FaRegEyeSlash /> : <FaRegEye />}
-                </button>
+              <div className="input-inner">
+                <label htmlFor="">닉네임</label>
+                <div className="input-inner__item">
+                  <input type="text" placeholder="닉네임을 입력해주세요" />
+                  <button className="btn-check">중복확인</button>
+                </div>
               </div>
-            </div>
-            <div className="input-inner">
-              <label htmlFor="">비밀번호 확인</label>
-              <div className="input-inner__item">
-                <input
+              <div className="input-inner">
+                <label htmlFor="">휴대폰 번호</label>
+                <input type="text" placeholder="숫자만 입력해주세요" />
+              </div>
+              <div className="input-inner">
+                <label htmlFor="">비밀번호</label>
+                <div className="input-inner__item">
+                  <input
                     placeholder="비밀번호를 입력해주세요"
-                    type={isPwsVisible ? "text" : "password"}
+                    type={isPwVisible ? "text" : "password"}
                   />
                   <button type="button"
                     className="btn-visible"
-                    onClick={() => togglePw('confirmPassword')}
+                    onClick={() => togglePw('password')}
                   >
-                    {isPwsVisible ? <FaRegEyeSlash /> : <FaRegEye />}
+                    {isPwVisible ? <FaRegEyeSlash /> : <FaRegEye />}
                   </button>
+                </div>
               </div>
-            </div>
-            <ul className="agree-inner">
-              <TermsAgreement />
-            </ul>
-              <CommonButton
-              text={'회원가입'}
-              buttonSize={'large'}
-              />
-            </div>
-          </form>
+              <div className="input-inner">
+                <label htmlFor="">비밀번호 확인</label>
+                <div className="input-inner__item">
+                  <input
+                      placeholder="비밀번호를 입력해주세요"
+                      type={isPwsVisible ? "text" : "password"}
+                    />
+                    <button type="button"
+                      className="btn-visible"
+                      onClick={() => togglePw('confirmPassword')}
+                    >
+                      {isPwsVisible ? <FaRegEyeSlash /> : <FaRegEye />}
+                    </button>
+                </div>
+              </div>
+              <ul className="agree-inner">
+                <TermsAgreement />
+              </ul>
+                <CommonButton
+                text={'회원가입'}
+                buttonSize={'large'}
+                />
+              </div>
+            </form>
+          </div>
         </div>
       </div>
     </>

--- a/src/pages/users/users.scss
+++ b/src/pages/users/users.scss
@@ -1,6 +1,6 @@
 @import '../../styles/common.scss';
 
-body {
+.user-wrap {
 	background-color: #9199a4;
 	overflow-y: scroll;
 }
@@ -8,7 +8,7 @@ body {
 .bg-wrap {
 	display: flex;
 	justify-content: flex-end;
-	margin: 200px 0;
+	margin: 25vh 0;
 	padding-right: 200px;
 	height: 100%;
 	@include mdq-max(1200) {


### PR DESCRIPTION
## 페이지
로그인/회원가입 페이지

## ✨ 작업 내용
- body 태그 스타일 전역으로 먹혔던 것 제거하고 고유한 이름으로 대체

## 📸 스크린샷

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 리액트에서 컴포넌트 단위로 생성/제거되는것처럼 scss 또한 컴포넌트별로 import 했기 때문에 
   해당 컴포넌트에만 적용되는 줄 알았지만 기존 css 처럼 Cascading(폭포식) 방식으로 적용이 된다는 점을 몰랐음

❗️그렇다면 각자 작업하는 컴포넌트가 다르다 할지라도 혹시나 이름이 겹친다면 스타일이 충돌되는 상황이 발생할 수 있을 것 같아서
알아보니 scss를 모듈화해서 사용하는 것이 안전함을 알게됨

.scss 확장자를 .module.scss 로 바꿔주기만 하면 클래스명이 자동으로 고유하게 생성되어 
<img width="216" alt="스크린샷 2023-11-25 오후 3 22 33" src="https://github.com/FC-FastCatch/FastCatch-FrontEnd/assets/95595106/af92f702-99d1-48b1-ad66-e101242502db">
부모 컴포넌트에서 정의한 스타일이 자식 컴포넌트에 영향을 미치지 않음. 
(프젝규모가 커진다면 scss 모듈방식을 꼭 사용해야할 것 같음 혹은 지금부터라도 적용하는것도 나쁘지 않을 것 같네요!)


close https://github.com/FC-FastCatch/FastCatch-FrontEnd/issues/33