### PR TITLE
[#56] 카테고리필터/디테일필터 작업 중간본(작업 도중 toss), 헤더의 모든 navigate버튼들 작동하게 하기

### DIFF
--- a/src/components/commonHeader/cartButton/CartButton.tsx
+++ b/src/components/commonHeader/cartButton/CartButton.tsx
@@ -1,10 +1,16 @@
 import { FiShoppingCart } from "react-icons/fi";
 import "./cartbutton.scss";
 import { useState /*, useEffect */ } from "react";
+import { useNavigate } from "react-router-dom";
 // import axios from "axios";
 
 const CartButton = () => {
-  const [cartItems /*, setCartItems */] = useState<string[]>([]);
+  const [cartItems] = useState<string[]>([]);
+  const navigate = useNavigate();
+
+  const moveToBasketHandler = () => {
+    navigate("/basket");
+  };
 
   // useEffect(() => {
   //   axios
@@ -14,7 +20,7 @@ const CartButton = () => {
   // }, [cartItems]);
 
   return (
-    <button className="header__cart-button">
+    <button className="header__cart-button" onClick={moveToBasketHandler}>
       <FiShoppingCart className="cart-button__icon" />
       <div className="cart-button__amount">{cartItems.length}</div>
     </button>

--- a/src/components/commonHeader/categoryFilter/CategoryFilter.tsx
+++ b/src/components/commonHeader/categoryFilter/CategoryFilter.tsx
@@ -6,7 +6,8 @@ import guestHouse from "../../../assets/categoryIcons/guest-house.jpg";
 import hotel from "../../../assets/categoryIcons/hotel.jpg";
 import motel from "../../../assets/categoryIcons/motel.jpg";
 import { IoOptionsOutline } from "react-icons/io5";
-// import ReactDOM from "react-dom";
+import DetailCategoryModal from "./DetailCategoryModal";
+import ReactDOM from "react-dom";
 
 interface categoryTypes {
   name: string;
@@ -23,9 +24,12 @@ const CategoryFilter = () => {
     { name: "팬션/풀빌라", img: hotel, select: false },
     { name: "게스트하우스", img: motel, select: false },
   ];
+  const [openDetail, setOpenDetail] = useState(false);
 
   const [categories, setCategories] = useState(categoriesData);
-  const detailOpenHandler = () => {};
+  const toggleDetailHandler = () => {
+    setOpenDetail((prev) => !prev);
+  };
 
   const changeCategoryHandler = (categoryName: string) => {
     const copy: categoryTypes[] = categories.slice().map((arg) => {
@@ -62,12 +66,12 @@ const CategoryFilter = () => {
           )
         )}
         <div className="filter__adjust-height">
-          <button className="filter__button-detail" onClick={detailOpenHandler}>
+          <button className="filter__button-detail" onClick={toggleDetailHandler}>
             <IoOptionsOutline className="detail__icon" />
             <span className="text-body3">필터</span>
           </button>
         </div>
-        {/* {ReactDOM.createPortal()} */}
+        {openDetail ? ReactDOM.createPortal(<DetailCategoryModal onClick={toggleDetailHandler} />, document.getElementById("root") as Element) : ""}
       </div>
     </div>
   );

--- a/src/components/commonHeader/categoryFilter/DetailCategoryModal.tsx
+++ b/src/components/commonHeader/categoryFilter/DetailCategoryModal.tsx
@@ -1,0 +1,15 @@
+import "./detailCategoryModal.scss";
+interface detailProps {
+  onClick: React.MouseEventHandler<HTMLDivElement>;
+}
+
+const DetailCategoryModal = (props: detailProps) => {
+  return (
+    <div className="detail-modal__container">
+      <div className="detail-backdrop" onClick={props.onClick}></div>
+      <div className="detail-modal">하하</div>
+    </div>
+  );
+};
+
+export default DetailCategoryModal;

--- a/src/components/commonHeader/categoryFilter/DetailCategoryModal.tsx
+++ b/src/components/commonHeader/categoryFilter/DetailCategoryModal.tsx
@@ -7,7 +7,7 @@ interface detailProps {
 }
 
 const DetailCategoryModal = (props: detailProps) => {
-  const commitHandler = (e: React.MouseEvent) => {};
+  // const commitHandler = (e: React.MouseEvent) => {};
 
   return (
     <div className="detail-modal__container">
@@ -36,7 +36,7 @@ const DetailCategoryModal = (props: detailProps) => {
             colorName="coral200"
             onClick={props.onClick as React.MouseEventHandler}
           />
-          <CommonButton text="확인" onClick={commitHandler} />
+          <CommonButton text="확인" /*onClick={commitHandler}*/ />
         </footer>
       </div>
     </div>

--- a/src/components/commonHeader/categoryFilter/DetailCategoryModal.tsx
+++ b/src/components/commonHeader/categoryFilter/DetailCategoryModal.tsx
@@ -1,13 +1,44 @@
+import { IoClose } from "react-icons/io5";
 import "./detailCategoryModal.scss";
+import CommonButton from "../../commonButton/CommonButton";
+
 interface detailProps {
   onClick: React.MouseEventHandler<HTMLDivElement>;
 }
 
 const DetailCategoryModal = (props: detailProps) => {
+  const commitHandler = (e: React.MouseEvent) => {};
+
   return (
     <div className="detail-modal__container">
       <div className="detail-backdrop" onClick={props.onClick}></div>
-      <div className="detail-modal">하하</div>
+      <div className="detail-modal__wrap">
+        <header className="detail-modal__header">
+          <span className="text-subtitle4">숙소필터</span>
+          <IoClose className="close-button" onClick={props.onClick} />
+        </header>
+        <section className="detail-modal__body">
+          <div className="body__section">
+            <label htmlFor="" className="text-subtitle5">
+              정렬
+            </label>
+            <button>버튼1</button>
+          </div>
+          <div className="body__section">
+            <label htmlFor="" className="text-subtitle5">
+              숙소 옵션
+            </label>
+          </div>
+        </section>
+        <footer className="detail-modal__footer">
+          <CommonButton //
+            text="취소"
+            colorName="coral200"
+            onClick={props.onClick as React.MouseEventHandler}
+          />
+          <CommonButton text="확인" onClick={commitHandler} />
+        </footer>
+      </div>
     </div>
   );
 };

--- a/src/components/commonHeader/categoryFilter/DetailedCategoryModal.tsx
+++ b/src/components/commonHeader/categoryFilter/DetailedCategoryModal.tsx
@@ -1,5 +1,0 @@
-const DetailedCategoryModal = () => {
-  return <div></div>;
-};
-
-export default DetailedCategoryModal;

--- a/src/components/commonHeader/categoryFilter/detailCategoryModal.scss
+++ b/src/components/commonHeader/categoryFilter/detailCategoryModal.scss
@@ -58,15 +58,15 @@
     flex-direction: column;
     gap: rem(32);
 
-    .body__section {
-    }
+    // .body__section {
+    // }
 
     label {
       display: block;
     }
 
-    button {
-    }
+    // button {
+    // }
   }
 
   .detail-modal__footer {

--- a/src/components/commonHeader/categoryFilter/detailCategoryModal.scss
+++ b/src/components/commonHeader/categoryFilter/detailCategoryModal.scss
@@ -1,0 +1,28 @@
+@import "../../../styles/common.scss";
+
+.detail-modal__container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1001;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+.detail-backdrop {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.2);
+  z-index: 1001;
+}
+
+.detail-modal {
+  width: 500px;
+  height: 500px;
+  background-color: red;
+}

--- a/src/components/commonHeader/categoryFilter/detailCategoryModal.scss
+++ b/src/components/commonHeader/categoryFilter/detailCategoryModal.scss
@@ -21,8 +21,62 @@
   z-index: 1001;
 }
 
-.detail-modal {
-  width: 500px;
+.detail-modal__wrap {
+  width: 650px;
   height: 500px;
-  background-color: red;
+  background-color: white;
+  border-radius: rem(16);
+  z-index: 1002;
+  display: flex;
+  flex-direction: column;
+
+  .detail-modal__header {
+    height: rem(66);
+    width: 100%;
+    padding: rem(24);
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: rem(1) solid gray(400);
+
+    .close-button {
+      font-size: rem(30);
+      border-radius: rem(4);
+
+      &:hover {
+        background-color: gray(200);
+      }
+    }
+  }
+
+  .detail-modal__body {
+    width: 100%;
+    flex-grow: 1;
+    padding: rem(24);
+    display: flex;
+    flex-direction: column;
+    gap: rem(32);
+
+    .body__section {
+    }
+
+    label {
+      display: block;
+    }
+
+    button {
+    }
+  }
+
+  .detail-modal__footer {
+    border-top: rem(1) solid gray(400);
+    height: rem(66);
+    width: 100%;
+    padding: rem(24);
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: rem(16);
+  }
 }

--- a/src/components/commonHeader/myInfo/MyInfo.tsx
+++ b/src/components/commonHeader/myInfo/MyInfo.tsx
@@ -1,8 +1,14 @@
+import { useNavigate } from "react-router-dom";
 import "./myInfo.scss";
 
 const MyInfo = () => {
+  const navigate = useNavigate();
+  const moveToMembersHandler = () => {
+    navigate("/members");
+  };
+
   return (
-    <button className="my-info-container">
+    <button className="my-info-container" onClick={moveToMembersHandler}>
       <div className="my-info-profileImage"></div>
       <span className="text-body3">김놀자</span>
     </button>

--- a/src/components/commonModal/commonModalLayout.scss
+++ b/src/components/commonModal/commonModalLayout.scss
@@ -1,61 +1,60 @@
-@import '../../styles/common.scss';
+@import "../../styles/common.scss";
 
 .modal-bg {
-	position: absolute;
-	left: 0;
-	top: 0;
-	z-index: -1;
-	width: 100%;
-	height: 100%;
-	background-color: rgba(0, 0, 0, 0.5);
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
 }
 
 .modal-wrap {
-	position: absolute;
-	z-index: 100;
-	left: 50%;
-	top: 50%;
-	transform: translate(-50%, -50%);
-	min-width: 490px;
-	background-color: white;
-	box-shadow: boxshadow(1);
-	border-radius: 8px;
-	&__header {
-		padding: 0 24px;
-		height: 70px;
-		line-height: 70px;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		.btn-close {
-			background-color: white;
-			padding: 0;
-			font-size: rem(30);
-			border: none;
-			display: inline-flex;
-			align-items: center;
-			justify-content: center;
-			&:focus {
-				outline: none;
-				border: none;
-			}
-		}
-	}
-	&__body {
-		padding: 16px 24px;
-		border-top: 1px solid #e5e9ed;
-		border-bottom: 1px solid #e5e9ed;
-		min-height: 160px;
-		max-height: 260px;
-		overflow-y: scroll;
-	}
-	&__footer {
-		padding: 0 24px;
-		height: 70px;
-		display: flex;
-		justify-content: flex-end;
-		align-items: center;
-		gap: 12px;
-	}
+  position: absolute;
+  z-index: 1002;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  min-width: 490px;
+  background-color: white;
+  box-shadow: shadow(1);
+  border-radius: 8px;
+  &__header {
+    padding: 0 24px;
+    height: 70px;
+    line-height: 70px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    .btn-close {
+      background-color: white;
+      padding: 0;
+      font-size: rem(30);
+      border: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      &:focus {
+        outline: none;
+        border: none;
+      }
+    }
+  }
+  &__body {
+    padding: 16px 24px;
+    border-top: 1px solid #e5e9ed;
+    border-bottom: 1px solid #e5e9ed;
+    min-height: 160px;
+    max-height: 260px;
+    overflow-y: scroll;
+  }
+  &__footer {
+    padding: 0 24px;
+    height: 70px;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+  }
 }
-


### PR DESCRIPTION
## 페이지
- 카테고리필터/디테일필터
- 헤더의 모든 navigate버튼들

## ✨ 작업 내용
- 카테고리필터/디테일 필터 부분
  - commonModal을 이용하려 했는데, 내용물이 너무 커서 commonFilter의 가장 큰 사이즈에도 안 들어가더라구요.
  그래서 commonFIlter의 width, height를 차라리 반응형으로 해서 적용하려다가, 다른 분들 코드에 영향갈거같고 그래서
  모달 새로 만들고 있었습니다.

#### in commonHeader/categoryFilter/detailCategoryFilter.tsx 입니다.

<img width="260" alt="image" src="https://github.com/FC-FastCatch/FastCatch-FrontEnd/assets/126222848/41c3fabe-eb89-4074-8350-0e60cce3c806">
 
[해당 부분 피그마 링크](https://www.figma.com/file/N8hvmLogptynu7SVsi0nWX/%EC%9D%B4%EA%B1%B0-%EB%8B%A4-%EB%90%98%EB%A9%B4-%ED%8C%94%EC%A1%B0%3F!?type=design&node-id=772-1327&mode=design&t=sydtS5REtjGsJ6HZ-4)

진짜 대충 정보만 이렇게 구성해야지라고 올려놓고 대강 스타일링하려고 했는데 이어서 진행해주시면 될거 같습니당!,,
그리고 이 필터들의 state를 어케할지 고민중이었습니다.


<br>
<br>
<br>

- 헤더의 모든 navigate버튼들
  - 장바구니 버튼 누르면 장바구니 페이지로 이동하고
  - 내정보 버튼 누르면 내 정보 페이지로 갑니다.


close https://github.com/FC-FastCatch/FastCatch-FrontEnd/issues/42