### PR TITLE
[#73] 주소 연결, 디테일 모달 연결, 디테일 모달 취소 로직 구현, 메인페이지 아이템 이름/주소 너무 길 시 말줄임 표시

### DIFF
--- a/src/components/commonFilter/CommonFilter.tsx
+++ b/src/components/commonFilter/CommonFilter.tsx
@@ -12,6 +12,7 @@ import AmountDropdown from "./filterDropdowns/AmountDropdown";
 import DateDropdown from "./filterDropdowns/DateDropdown";
 import LocationDropdown from "./filterDropdowns/LocationDropdown";
 import { responseState } from "@/src/states/responseState";
+import { detailState } from "@/src/states/detailState";
 
 interface filterProps {
   isLocale?: boolean;
@@ -20,6 +21,7 @@ interface filterProps {
 
 const CommonFilter = (props: filterProps) => {
   const setResponseStates = useSetRecoilState(responseState);
+  const setDetailStates = useSetRecoilState(detailState);
   const [isSelected, setIsSelected] = useState<
     "location" | "date" | "amount" | null
   >(null);
@@ -40,6 +42,7 @@ const CommonFilter = (props: filterProps) => {
       pageIndex: 0,
       responseArray: [],
     });
+    setDetailStates([]);
     setIsSelected(null);
   };
 

--- a/src/components/commonHeader/categoryFilter/CategoryFilter.tsx
+++ b/src/components/commonHeader/categoryFilter/CategoryFilter.tsx
@@ -18,6 +18,7 @@ import DetailCategoryModal from "../../../pages/home/detailFilter/DetailCategory
 import { filterState, filterStateTypes } from "@/src/states/filterState";
 import { AccommodationType } from "@/src/types/accommodations";
 import { responseState } from "@/src/states/responseState";
+import { detailState } from "@/src/states/detailState";
 
 interface categoryTypes {
   name: string;
@@ -29,6 +30,7 @@ interface categoryTypes {
 const CategoryFilter = () => {
   const setFilterStates = useSetRecoilState(filterState);
   const setResponseStates = useSetRecoilState(responseState);
+  const setDetailStates = useSetRecoilState(detailState);
 
   const categoriesData: //
   categoryTypes[] = [
@@ -94,10 +96,10 @@ const CategoryFilter = () => {
             <button //
               key={`category-filter-${idx}`}
               className="filter__button categorySelect"
-              onClick={_debounce(
-                () => changeCategoryHandler(category.name),
-                100
-              )}
+              onClick={_debounce(() => {
+                setDetailStates([]);
+                changeCategoryHandler(category.name);
+              }, 100)}
             >
               <img src={category.img}></img>
               <span>{category.name}</span>
@@ -106,10 +108,10 @@ const CategoryFilter = () => {
             <button //
               key={idx}
               className="filter__button"
-              onClick={_debounce(
-                () => changeCategoryHandler(category.name),
-                100
-              )}
+              onClick={_debounce(() => {
+                setDetailStates([]);
+                changeCategoryHandler(category.name);
+              }, 100)}
             >
               <img src={category.img}></img>
               <span>{category.name}</span>

--- a/src/constant/categories.ts
+++ b/src/constant/categories.ts
@@ -21,11 +21,7 @@ export const regionData: regionCategory = {
 };
 
 export interface AccommodationCategory {
-  ALL: "전체";
-  PENSION: "팬션/풀빌라";
-  HOTELRESORT: "호텔/리조트";
-  MOTEL: "모텔";
-  GUESTHOUSE: "게스트하우스";
+  [ALL: string]: string;
 }
 
 export const accommodationCategoryData: AccommodationCategory = {

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -9,10 +9,13 @@ import { fetchAccommodationsData } from "@/src/hooks/fetchAccommodations";
 import { Accommodation } from "../../types/accommodations";
 import { responseState } from "@/src/states/responseState";
 import { useEffect, useRef } from "react";
+import { detailState } from "@/src/states/detailState";
 
 const Home = () => {
+  const [detailFiltered, setDetailFiltered] = useRecoilState(detailState);
   const [filterStates] = useRecoilState(filterState);
   const [responseStates, setResponseStates] = useRecoilState(responseState);
+
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -77,15 +80,25 @@ const Home = () => {
   return (
     <div className="home-wrapper">
       <div className="home-inner">
-        {responseStates.responseArray.length !== 0
+        {detailFiltered.length === 0
           ? responseStates.responseArray.map((acc: Accommodation) => (
               <AccomodationItem key={acc.id} data={acc} />
             ))
-          : "없어요"}
+          : detailFiltered.map(acc => (
+              <AccomodationItem key={acc.id} data={acc} />
+            ))}
         <div className="target-div" ref={scrollRef}>
           @2023 빨리 잡아
         </div>
       </div>
+      {detailFiltered.length !== 0 && (
+        <button
+          className="home__filter-reset"
+          onClick={() => setDetailFiltered([])}
+        >
+          세부필터 해제
+        </button>
+      )}
     </div>
   );
 };

--- a/src/pages/home/accomodationItem/AccomodationItem.tsx
+++ b/src/pages/home/accomodationItem/AccomodationItem.tsx
@@ -2,10 +2,7 @@ import { CommonBadge } from "@/src/components";
 import "./accomodationItem.scss";
 import numberFormat from "@/src/utils/numberFormat";
 import { useNavigate } from "react-router-dom";
-import {
-  accommodationCategoryData,
-  regionData,
-} from "@/src/constant/categories";
+import { accommodationCategoryData } from "@/src/constant/categories";
 import { Accommodation } from "../../../types/accommodations";
 interface accommodationProps {
   data: Accommodation;
@@ -29,10 +26,10 @@ const AccommodationItem = ({ data }: accommodationProps) => {
         <div className="item-info">
           <div>
             <strong className="text-subtitle5">{data.name}</strong>
-            <div className="text-body2 item-info__lacation">
+            <div className="text-body2 item-info__location">
               <p>
                 {accommodationCategoryData[data.category]} |{" "}
-                {regionData[data.region]}
+                {data.address?.split(" ").slice(0, 3).join(" ") || data.region}
               </p>
             </div>
           </div>

--- a/src/pages/home/accomodationItem/accomodationItem.scss
+++ b/src/pages/home/accomodationItem/accomodationItem.scss
@@ -30,8 +30,23 @@
     .item-info {
       display: flex;
       justify-content: space-between;
-      &__lacation {
+      strong {
+        display: block;
+        width: 280px;
+
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      &__location p {
+        display: block;
+        width: 280px;
         color: gray(700);
+
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
     }
 

--- a/src/pages/home/detailFilter/DetailCategoryModal.tsx
+++ b/src/pages/home/detailFilter/DetailCategoryModal.tsx
@@ -1,8 +1,8 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "react-query";
-import { useSetRecoilState } from "recoil";
+import { useSetRecoilState, useRecoilState } from "recoil";
 import { detailState } from "@/src/states/detailState";
-import { commitOptions } from './detailCommitFnc';
+import { commitOptions } from "./detailCommitFnc";
 import { CommonButton } from "@/src/components";
 import TermsAgreementItem from "@/src/components/termsAgreementItem/TermsAgreementItem";
 import { IoClose } from "react-icons/io5";
@@ -17,7 +17,7 @@ export interface OptionI {
 
 interface detailProps {
   onClick: React.MouseEventHandler<HTMLDivElement>;
-  setOpenDetail: React.Dispatch<React.SetStateAction<boolean>>; 
+  setOpenDetail: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const filterOption = {
@@ -29,32 +29,41 @@ const filterOption = {
   hasGym: "헬스장",
   hasBreakfast: "조식",
   hasRestaurant: "레스토랑",
-  hasCookingRoom: "취사 가능"
+  hasCookingRoom: "취사 가능",
 };
 
-const DetailCategoryModal = (props : detailProps) => {
-
+const DetailCategoryModal = (props: detailProps) => {
   const queryClient = useQueryClient();
+  const [detail] = useRecoilState(detailState);
   const setFilteredAtom = useSetRecoilState(detailState);
-  const setOpenDetail = props.setOpenDetail
+  const setOpenDetail = props.setOpenDetail;
+
+  useEffect(() => {
+    console.log(detail);
+  }, [detail]);
 
   const [activeTab, setActiveTab] = useState<number>(0);
   const [options, setOptions] = useState<OptionI[]>([
-    { key: 'hasSmokingRoom', label: filterOption.hasSmokingRoom, state: false },
-    { key: 'hasPetRoom', label: filterOption.hasPetRoom, state: false },
-    { key: 'hasParkingLot', label: filterOption.hasParkingLot, state: false },
-    { key: 'hasWifi', label: filterOption.hasWifi, state: false },
-    { key: 'hasSwimmingPool', label: filterOption.hasSwimmingPool, state: false },
-    { key: 'hasGym', label: filterOption.hasGym, state: false },
-    { key: 'hasBreakfast', label: filterOption.hasBreakfast, state: false },
-    { key: 'hasRestaurant', label: filterOption.hasRestaurant, state: false },
-    { key: 'hasCookingRoom', label: filterOption.hasCookingRoom, state: false },
+    { key: "hasSmokingRoom", label: filterOption.hasSmokingRoom, state: false },
+    { key: "hasPetRoom", label: filterOption.hasPetRoom, state: false },
+    { key: "hasParkingLot", label: filterOption.hasParkingLot, state: false },
+    { key: "hasWifi", label: filterOption.hasWifi, state: false },
+    {
+      key: "hasSwimmingPool",
+      label: filterOption.hasSwimmingPool,
+      state: false,
+    },
+    { key: "hasGym", label: filterOption.hasGym, state: false },
+    { key: "hasBreakfast", label: filterOption.hasBreakfast, state: false },
+    { key: "hasRestaurant", label: filterOption.hasRestaurant, state: false },
+    { key: "hasCookingRoom", label: filterOption.hasCookingRoom, state: false },
   ]);
-  const [translateFilterSlider, setTranslateFilterSlider] = useState<string>("0");
+  const [translateFilterSlider, setTranslateFilterSlider] =
+    useState<string>("0");
   const filterButtonsRef = useRef<Array<HTMLButtonElement | null>>(
     Array.from({ length: 4 }, () => null)
   );
-  
+
   // 첫번째 필터 (순서정렬)
   const sortOptions = (index: number, value: string) => {
     setActiveTab(index);
@@ -65,7 +74,7 @@ const DetailCategoryModal = (props : detailProps) => {
       }
     });
     if (filterButtonsRef.current[index]!) {
-      filterButtonsRef.current[index]!.classList.add('filter-active');
+      filterButtonsRef.current[index]!.classList.add("filter-active");
     }
   };
 
@@ -75,10 +84,16 @@ const DetailCategoryModal = (props : detailProps) => {
     updatedOptions[index].state = !updatedOptions[index].state;
     setOptions(updatedOptions);
   };
-  
+
   // 필터 함수 실행
   const commitOptionsHandler = () => {
-    commitOptions(activeTab, options, queryClient, setFilteredAtom, setOpenDetail);
+    commitOptions(
+      activeTab,
+      options,
+      queryClient,
+      setFilteredAtom,
+      setOpenDetail
+    );
   };
 
   return (
@@ -91,22 +106,22 @@ const DetailCategoryModal = (props : detailProps) => {
         </header>
         <section className="detail-modal__body">
           <div className="body__section">
-            <p className="text-subtitle5 filter-tit">
-              정렬
-            </p>
+            <p className="text-subtitle5 filter-tit">정렬</p>
             <div className="filters-wrapper">
               <ul className="filter-tabs">
                 {[
-                  { index: 0, label: '등록순', value: '0' },
-                  { index: 1, label: '가격낮은순', value: '100%' },
-                  { index: 2, label: '가격높은순', value: '200%' },
-                  { index: 3, label: '가나다순', value: '300%' },
+                  { index: 0, label: "등록순", value: "0" },
+                  { index: 1, label: "가격낮은순", value: "100%" },
+                  { index: 2, label: "가격높은순", value: "200%" },
+                  { index: 3, label: "가나다순", value: "300%" },
                 ].map(({ index, label, value }) => (
                   <li key={`filter-${index}`}>
                     <button
-                      className={`filter-button ${activeTab === index ? "filter-active" : ""}`}
+                      className={`filter-button ${
+                        activeTab === index ? "filter-active" : ""
+                      }`}
                       onClick={() => sortOptions(index, value)}
-                      ref={(element) => {
+                      ref={element => {
                         filterButtonsRef.current[index] = element;
                       }}
                     >
@@ -116,15 +131,17 @@ const DetailCategoryModal = (props : detailProps) => {
                 ))}
               </ul>
               <div className="filter-slider" aria-hidden="true">
-                <div className="filter-slider-rect" 
-                style={{ transform: `translateX(${translateFilterSlider})`}}>&nbsp;</div>
+                <div
+                  className="filter-slider-rect"
+                  style={{ transform: `translateX(${translateFilterSlider})` }}
+                >
+                  &nbsp;
+                </div>
               </div>
             </div>
           </div>
           <div className="body__section">
-            <p className="text-subtitle5 filter-tit">
-              숙소 옵션
-            </p>
+            <p className="text-subtitle5 filter-tit">숙소 옵션</p>
             <div className="option-wrap">
               {options.map((option, index) => (
                 <TermsAgreementItem
@@ -137,6 +154,10 @@ const DetailCategoryModal = (props : detailProps) => {
                 />
               ))}
             </div>
+            <div className="text-body3 tipped">
+              *현 시점에서 세부 필터는 현재까지 불러온 데이터들을 추려보는
+              용도로만 사용가능합니다.
+            </div>
           </div>
         </section>
         <footer className="detail-modal__footer">
@@ -145,9 +166,7 @@ const DetailCategoryModal = (props : detailProps) => {
             colorName="coral200"
             onClick={props.onClick as React.MouseEventHandler}
           />
-          <CommonButton 
-          text="확인" 
-          onClick={commitOptionsHandler} />
+          <CommonButton text="확인" onClick={commitOptionsHandler} />
         </footer>
       </div>
     </div>

--- a/src/pages/home/detailFilter/detailCategoryModal.scss
+++ b/src/pages/home/detailFilter/detailCategoryModal.scss
@@ -143,6 +143,17 @@
       display: block;
       margin-bottom: 8px;
     }
+    .tipped {
+      margin-top: rem(40);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      border-radius: rem(8);
+      background-color: gray(200);
+      height: rem(48);
+      color: gray(800);
+    }
   }
 
   .detail-modal__footer {

--- a/src/pages/home/detailFilter/detailCommitFnc.ts
+++ b/src/pages/home/detailFilter/detailCommitFnc.ts
@@ -9,9 +9,8 @@ export const commitOptions = (
   setFilteredAtom: React.Dispatch<React.SetStateAction<Accommodation[]>>,
   setOpenDetail: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
-
-  const selectedOptions = options.filter((option) => option.state);
-  const cachedMainData: any = queryClient.getQueryData(['accommodations']);
+  const selectedOptions = options.filter(option => option.state);
+  const cachedMainData: any = queryClient.getQueryData(["accommodations"]);
   const cachedData = cachedMainData.data.accommodations;
 
   if (cachedData) {
@@ -20,13 +19,19 @@ export const commitOptions = (
     // 첫번째 필터 (순서정렬)
     switch (activeTab) {
       case 1:
-        sortedData = [...cachedData].sort((a, b) => a.lowestPrice - b.lowestPrice);
+        sortedData = [...cachedData].sort(
+          (a, b) => a.lowestPrice - b.lowestPrice
+        );
         break;
       case 2:
-        sortedData = [...cachedData].sort((a, b) => b.lowestPrice - a.lowestPrice);
+        sortedData = [...cachedData].sort(
+          (a, b) => b.lowestPrice - a.lowestPrice
+        );
         break;
       case 3:
-        sortedData = [...cachedData].sort((a, b) => a.name.localeCompare(b.name));
+        sortedData = [...cachedData].sort((a, b) =>
+          a.name.localeCompare(b.name)
+        );
         break;
       default:
         sortedData = [...cachedData];
@@ -35,12 +40,16 @@ export const commitOptions = (
 
     // 두번째 필터 (옵션선택)
     const filteredData = selectedOptions.length
-    ? sortedData.filter(item => selectedOptions.every(selectedOption => item.accommodationOption[selectedOption.key]))
-    : sortedData;
+      ? sortedData.filter(item =>
+          selectedOptions.every(
+            selectedOption => item.accommodationOption[selectedOption.key]
+          )
+        )
+      : sortedData;
 
     // 필터된 값 전역상태 저장
     setFilteredAtom(filteredData);
-    console.log('필터된 데이터', filteredData);
+    console.log("필터된 데이터", filteredData);
 
     // 모달창 닫기
     setOpenDetail(false);

--- a/src/pages/home/home.scss
+++ b/src/pages/home/home.scss
@@ -36,3 +36,22 @@
   color: gray(600);
   margin-top: rem(40);
 }
+
+.home__filter-reset {
+  position: absolute;
+  bottom: rem(40);
+  left: 0;
+  right: 0;
+  margin: auto;
+
+  width: rem(240);
+  height: rem(40);
+  box-shadow: shadow(3);
+  color: white;
+  border-radius: rem(8);
+  background-color: coral(300);
+
+  &:hover {
+    background-color: coral(400);
+  }
+}

--- a/src/types/accommodations.ts
+++ b/src/types/accommodations.ts
@@ -1,10 +1,11 @@
 // Accommodations 객체입니다.
 export interface Accommodation {
-  category: "ALL" | "PENSION" | "HOTELRESORT" | "MOTEL" | "GUESTHOUSE";
+  category: "ALL" | "PENSION" | "HOTELRESORT" | "MOTEL" | "GUESTHOUSE" | string;
   id: number;
   image: string;
   lowestPrice: number;
   name: string;
+  address?: string;
   region:
     | "ALL"
     | "GYEONGGI"
@@ -13,13 +14,15 @@ export interface Accommodation {
     | "CHUNGCHEONG"
     | "HONAM"
     | "GYEONGSANG"
-    | "JEJU";
-  soldOut: false;
+    | "JEJU"
+    | string;
+  soldOut: boolean;
 }
 
 export interface Accommodations {
   category: "ALL" | "PENSION" | "HOTELRESORT" | "MOTEL" | "GUESTHOUSE";
   accommodations: Accommodation[];
+  address?: string;
   id: number;
   image: string;
   lowestPrice: number;


### PR DESCRIPTION
## 페이지
메인페이지

## ✨ 작업 내용

1. 디테일 모달 연결

모달 하단부에 추가적으로 현재까지 불러온 데이터에 대해서만 필터링이 가능하다는 것을 명시했습니다.

<img width="837" alt="image" src="https://github.com/FC-FastCatch/FastCatch-FrontEnd/assets/126222848/1a9af8c9-baaf-484d-9f2c-f9885525554f">


2. 디테일 모달 적용 시 취소 로직 구현
- 현재 detailFiltered(필터링 된 배열)의 길이가 0이면 기존 배열 보여주고,
- detailedFiltered가 길이가 1 이상이면 필터를 보여주고 있습니다.

<img width="417" alt="image" src="https://github.com/FC-FastCatch/FastCatch-FrontEnd/assets/126222848/9636cd0c-84eb-45bd-bd74-a66ad1012944">
 
- 그러나 세부필터 취소 버튼(detailedFilter가 1 이상일 때 표출)을 눌러 전체보기 로직으로 돌아갈 수 있게 했습니다.
- 추가적으로, 다른 카테고리를 선택하거나 필터 조회버튼을 눌러도 detailedFiltered를 싹 비우고(길이를 0으로 만들고) 기존 전체보기 로직을 수행합니다.

<img width="818" alt="image" src="https://github.com/FC-FastCatch/FastCatch-FrontEnd/assets/126222848/532d6a07-4cae-4209-927a-aa7b75808b42">


3. 주소 연결, 이름/주소 말줄임 처리

<img width="627" alt="스크린샷 2023-11-30 오후 5 55 07" src="https://github.com/FC-FastCatch/FastCatch-FrontEnd/assets/126222848/8696b513-d6bc-4c90-8e7b-8b5735411f7a">


close https://github.com/FC-FastCatch/FastCatch-FrontEnd/issues/73