### PR TITLE
[#103] 필터 버그 수정 및 필터링 시 선택 카테고리만 담게 설정

### DIFF
--- a/src/pages/accommodation/accommodationMap/AccommodationMap.tsx
+++ b/src/pages/accommodation/accommodationMap/AccommodationMap.tsx
@@ -39,6 +39,9 @@ const AccommodationMap = ({
   const { showToast, ToastContainer } = ToastLayout();
 
   useEffect(() => {
+    if (!window.kakao) {
+      return;
+    }
     let markers: any[] = [];
     let currCategory = "";
     const map = new kakao.maps.Map(mapContainer.current, options);
@@ -99,17 +102,16 @@ const AccommodationMap = ({
         .current!.querySelector(`#${currCategory}`)!
         .getAttribute("data-order");
 
-      for (let i = 0; i < places.length; i++) {
-        // 마커를 생성 & 표시
+      for (const place of places) {
         const marker = addMarker(
-          new kakao.maps.LatLng(places[i].y, places[i].x),
+          new kakao.maps.LatLng(place.y, place.x),
           order
         );
         (function (marker, place) {
           kakao.maps.event.addListener(marker, "click", function () {
             displayPlaceInfo(place);
           });
-        })(marker, places[i]);
+        })(marker, place);
       }
     }
 
@@ -140,8 +142,8 @@ const AccommodationMap = ({
     }
 
     function removeMarker() {
-      for (let i = 0; i < markers.length; i++) {
-        markers[i].setMap();
+      for (const marker of markers) {
+        marker.setMap();
       }
       markers = [];
     }
@@ -154,11 +156,9 @@ const AccommodationMap = ({
     // 각 카테고리에 클릭 이벤트
     function addCategoryClickEvent() {
       const category = categoryRef.current!;
-      const children: any = category!.children;
-      console.log(children, "children");
-      for (let i = 0; i < children.length; i++) {
-        // children[i].addEventListener("click", onClickCategory);
-        children[i].onclick = onClickCategory;
+      const children: any = category.children;
+      for (const child of children) {
+        child.onclick = onClickCategory;
       }
     }
     function onClickCategory(this: HTMLElement, event: any) {
@@ -181,8 +181,8 @@ const AccommodationMap = ({
     function changeCategoryClass(el: { className: string } | null) {
       const category = categoryRef.current!;
       const children = category!.children;
-      for (let i = 0; i < children.length; i++) {
-        children[i].className = "";
+      for (const child of children) {
+        child.className = "";
       }
 
       if (el) {
@@ -193,7 +193,7 @@ const AccommodationMap = ({
     customOverlay.setMap(map);
     placeOverlay.setMap(map);
     marker.setMap(map);
-  }, []);
+  }, [window.kakao]);
 
   return (
     <div className="accommodation__map">

--- a/src/pages/accommodation/accommodationMap/AccommodationMap.tsx
+++ b/src/pages/accommodation/accommodationMap/AccommodationMap.tsx
@@ -39,9 +39,6 @@ const AccommodationMap = ({
   const { showToast, ToastContainer } = ToastLayout();
 
   useEffect(() => {
-    if (!window.kakao) {
-      return;
-    }
     let markers: any[] = [];
     let currCategory = "";
     const map = new kakao.maps.Map(mapContainer.current, options);
@@ -102,16 +99,17 @@ const AccommodationMap = ({
         .current!.querySelector(`#${currCategory}`)!
         .getAttribute("data-order");
 
-      for (const place of places) {
+      for (let i = 0; i < places.length; i++) {
+        // 마커를 생성 & 표시
         const marker = addMarker(
-          new kakao.maps.LatLng(place.y, place.x),
+          new kakao.maps.LatLng(places[i].y, places[i].x),
           order
         );
         (function (marker, place) {
           kakao.maps.event.addListener(marker, "click", function () {
             displayPlaceInfo(place);
           });
-        })(marker, place);
+        })(marker, places[i]);
       }
     }
 
@@ -142,8 +140,8 @@ const AccommodationMap = ({
     }
 
     function removeMarker() {
-      for (const marker of markers) {
-        marker.setMap();
+      for (let i = 0; i < markers.length; i++) {
+        markers[i].setMap();
       }
       markers = [];
     }
@@ -156,9 +154,11 @@ const AccommodationMap = ({
     // 각 카테고리에 클릭 이벤트
     function addCategoryClickEvent() {
       const category = categoryRef.current!;
-      const children: any = category.children;
-      for (const child of children) {
-        child.onclick = onClickCategory;
+      const children: any = category!.children;
+      console.log(children, "children");
+      for (let i = 0; i < children.length; i++) {
+        // children[i].addEventListener("click", onClickCategory);
+        children[i].onclick = onClickCategory;
       }
     }
     function onClickCategory(this: HTMLElement, event: any) {
@@ -181,8 +181,8 @@ const AccommodationMap = ({
     function changeCategoryClass(el: { className: string } | null) {
       const category = categoryRef.current!;
       const children = category!.children;
-      for (const child of children) {
-        child.className = "";
+      for (let i = 0; i < children.length; i++) {
+        children[i].className = "";
       }
 
       if (el) {
@@ -193,7 +193,7 @@ const AccommodationMap = ({
     customOverlay.setMap(map);
     placeOverlay.setMap(map);
     marker.setMap(map);
-  }, [window.kakao]);
+  }, []);
 
   return (
     <div className="accommodation__map">

--- a/src/pages/home/detailFilter/DetailCategoryModal.tsx
+++ b/src/pages/home/detailFilter/DetailCategoryModal.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useQueryClient } from "react-query";
-import { useSetRecoilState, useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { detailState } from "@/states/detailState";
 import { commitOptions } from "./detailCommitFnc";
 import TermsAgreementItem from "@/components/termsAgreementItem/TermsAgreementItem";
@@ -8,6 +7,7 @@ import { IoClose } from "react-icons/io5";
 
 import "./detailCategoryModal.scss";
 import { Button } from "@/components/common";
+import { responseState } from "@/states/responseState";
 
 export interface OptionI {
   key: string;
@@ -33,7 +33,9 @@ const filterOption = {
 };
 
 const DetailCategoryModal = (props: detailProps) => {
-  const queryClient = useQueryClient();
+  // const queryClient = useQueryClient();
+  const [responseStates] = useRecoilState(responseState);
+  // responseArray
   const [detail] = useRecoilState(detailState);
   const setFilteredAtom = useSetRecoilState(detailState);
   const setOpenDetail = props.setOpenDetail;
@@ -90,7 +92,7 @@ const DetailCategoryModal = (props: detailProps) => {
     commitOptions(
       activeTab,
       options,
-      queryClient,
+      responseStates,
       setFilteredAtom,
       setOpenDetail
     );

--- a/src/pages/home/detailFilter/DetailCategoryModal.tsx
+++ b/src/pages/home/detailFilter/DetailCategoryModal.tsx
@@ -33,9 +33,7 @@ const filterOption = {
 };
 
 const DetailCategoryModal = (props: detailProps) => {
-  // const queryClient = useQueryClient();
   const [responseStates] = useRecoilState(responseState);
-  // responseArray
   const [detail] = useRecoilState(detailState);
   const setFilteredAtom = useSetRecoilState(detailState);
   const setOpenDetail = props.setOpenDetail;

--- a/src/pages/home/detailFilter/detailCommitFnc.ts
+++ b/src/pages/home/detailFilter/detailCommitFnc.ts
@@ -1,4 +1,3 @@
-import { responseStateTypes } from "./../../../states/responseState";
 import { OptionI } from "./DetailCategoryModal";
 import { Accommodation } from "@/states/detailState";
 

--- a/src/pages/home/detailFilter/detailCommitFnc.ts
+++ b/src/pages/home/detailFilter/detailCommitFnc.ts
@@ -1,17 +1,16 @@
-import { QueryClient } from "react-query";
+import { responseStateTypes } from "./../../../states/responseState";
 import { OptionI } from "./DetailCategoryModal";
 import { Accommodation } from "@/states/detailState";
 
 export const commitOptions = (
   activeTab: number,
   options: OptionI[],
-  queryClient: QueryClient,
+  responseStates: any,
   setFilteredAtom: React.Dispatch<React.SetStateAction<Accommodation[]>>,
   setOpenDetail: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
   const selectedOptions = options.filter(option => option.state);
-  const cachedMainData: any = queryClient.getQueryData(["accommodations"]);
-  const cachedData = cachedMainData.data.accommodations;
+  const cachedData = responseStates.responseArray;
 
   if (cachedData) {
     let sortedData;


### PR DESCRIPTION
## 페이지
디테일필터 모달

## ✨ 작업 내용
- 필터 적용시 'accommodation 타입을 참조할 수 없음'이라는 에러가 나오는데, 이를 해결. 
(필터링된 배열이 cachedData.data.accommodation 였는데 responseStates.responseArray로 변경)

- 필터 적용 시 이전 선택한 카테고리를 기준으로 데이터를 보여주는 버그 존재
  - (queryKey ["Accommodation", filterstates.current]로 불러와야 하는데 "Accommodation"으로만 불러와서 생긴 현상)
    - 그러나 필터 로직이 현재 ts파일에 구현되어 있어서 recoilstate를 불러올 수 없음(recoilstate는 jsx, tsx파일에서만 불러올 수 있음)
    - 리액트 쿼리클라이언트로 배열을 불러오는게 아니라 responseStates(전역으로 관리되는 서버응답 배열)를 디테일모달에서 가져와서 패러미터로 필터 로직 함수에 전달해서 해결


close https://github.com/FC-FastCatch/FastCatch-FrontEnd/issues/103