### PR TITLE
[#116] 헤더, 필터, 메인페이지 반응형 대응

### DIFF
--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -89,7 +89,7 @@ const Header = () => {
             )}
             {filterMode === "search" && <SearchFilter />}
             <button
-              className="filter__secondary-button"
+              className="filter__secondary-button media"
               onClick={changeFilterModeHandler}
             >
               {filterMode === "filter" && (

--- a/src/components/common/header/cartButton/cartbutton.scss
+++ b/src/components/common/header/cartButton/cartbutton.scss
@@ -10,6 +10,10 @@
   position: relative;
   color: gray(700);
 
+  @media (max-width: 1200px) {
+    padding: rem(4);
+  }
+
   .cart-button__icon {
     font-size: rem(20);
     margin: 6px;

--- a/src/components/common/header/categoryFilter/categoryFilter.scss
+++ b/src/components/common/header/categoryFilter/categoryFilter.scss
@@ -12,6 +12,11 @@
   border-bottom: rem(1) solid gray(400);
   box-shadow: shadow(1);
   user-select: none;
+
+  @media (max-width: 1200px) {
+    padding: 0 20px;
+    min-width: 900px;
+  }
 }
 
 .category-filter__inner {

--- a/src/components/common/header/header.scss
+++ b/src/components/common/header/header.scss
@@ -11,6 +11,11 @@
   background-color: white;
 
   border-bottom: 1px solid gray(300);
+
+  @media (max-width: 1200px) {
+    padding: 0 20px;
+    min-width: 900px;
+  }
 }
 
 .header-container__inner {
@@ -37,18 +42,29 @@
 
 .header-container__center {
   position: relative;
-  width: 40%;
+  width: calc(1192 * 0.4px);
   height: 100%;
 
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-shrink: 0;
+
+  @media (max-width: 1200px) {
+    justify-content: flex-start;
+  }
 }
 
 .filter__divider {
   width: rem(1);
   height: rem(16);
   background-color: gray(500);
+}
+
+.media {
+  @media (max-width: 1200px) {
+    position: relative;
+  }
 }
 
 .header-container__right {
@@ -64,4 +80,5 @@
   font-family: "CWDangamAsac-Bold";
   color: coral(500);
   font-size: rem(32);
+  white-space: nowrap;
 }

--- a/src/components/common/header/myInfo/myInfo.scss
+++ b/src/components/common/header/myInfo/myInfo.scss
@@ -37,5 +37,9 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+
+    @media (max-width: 1200px) {
+      display: none;
+    }
   }
 }

--- a/src/pages/accommodation/accommodationMap/AccommodationMap.tsx
+++ b/src/pages/accommodation/accommodationMap/AccommodationMap.tsx
@@ -39,6 +39,9 @@ const AccommodationMap = ({
   const { showToast, ToastContainer } = ToastLayout();
 
   useEffect(() => {
+    if (!window.kakao) {
+      return;
+    }
     let markers: any[] = [];
     let currCategory = "";
     const map = new kakao.maps.Map(mapContainer.current, options);
@@ -99,17 +102,16 @@ const AccommodationMap = ({
         .current!.querySelector(`#${currCategory}`)!
         .getAttribute("data-order");
 
-      for (let i = 0; i < places.length; i++) {
-        // 마커를 생성 & 표시
+      for (const place of places) {
         const marker = addMarker(
-          new kakao.maps.LatLng(places[i].y, places[i].x),
+          new kakao.maps.LatLng(place.y, place.x),
           order
         );
         (function (marker, place) {
           kakao.maps.event.addListener(marker, "click", function () {
             displayPlaceInfo(place);
           });
-        })(marker, places[i]);
+        })(marker, place);
       }
     }
 
@@ -140,8 +142,8 @@ const AccommodationMap = ({
     }
 
     function removeMarker() {
-      for (let i = 0; i < markers.length; i++) {
-        markers[i].setMap();
+      for (const marker of markers) {
+        marker.setMap();
       }
       markers = [];
     }
@@ -154,11 +156,9 @@ const AccommodationMap = ({
     // 각 카테고리에 클릭 이벤트
     function addCategoryClickEvent() {
       const category = categoryRef.current!;
-      const children: any = category!.children;
-      console.log(children, "children");
-      for (let i = 0; i < children.length; i++) {
-        // children[i].addEventListener("click", onClickCategory);
-        children[i].onclick = onClickCategory;
+      const children: any = category.children;
+      for (const child of children) {
+        child.onclick = onClickCategory;
       }
     }
     function onClickCategory(this: HTMLElement, event: any) {
@@ -181,8 +181,8 @@ const AccommodationMap = ({
     function changeCategoryClass(el: { className: string } | null) {
       const category = categoryRef.current!;
       const children = category!.children;
-      for (let i = 0; i < children.length; i++) {
-        children[i].className = "";
+      for (const child of children) {
+        child.className = "";
       }
 
       if (el) {
@@ -193,7 +193,7 @@ const AccommodationMap = ({
     customOverlay.setMap(map);
     placeOverlay.setMap(map);
     marker.setMap(map);
-  }, []);
+  }, [window.kakao]);
 
   return (
     <div className="accommodation__map">

--- a/src/pages/accommodation/accommodationMap/AccommodationMap.tsx
+++ b/src/pages/accommodation/accommodationMap/AccommodationMap.tsx
@@ -39,9 +39,6 @@ const AccommodationMap = ({
   const { showToast, ToastContainer } = ToastLayout();
 
   useEffect(() => {
-    if (!window.kakao) {
-      return;
-    }
     let markers: any[] = [];
     let currCategory = "";
     const map = new kakao.maps.Map(mapContainer.current, options);
@@ -102,16 +99,17 @@ const AccommodationMap = ({
         .current!.querySelector(`#${currCategory}`)!
         .getAttribute("data-order");
 
-      for (const place of places) {
+      for (let i = 0; i < places.length; i++) {
+        // 마커를 생성 & 표시
         const marker = addMarker(
-          new kakao.maps.LatLng(place.y, place.x),
+          new kakao.maps.LatLng(places[i].y, places[i].x),
           order
         );
         (function (marker, place) {
           kakao.maps.event.addListener(marker, "click", function () {
             displayPlaceInfo(place);
           });
-        })(marker, place);
+        })(marker, places[i]);
       }
     }
 
@@ -142,8 +140,8 @@ const AccommodationMap = ({
     }
 
     function removeMarker() {
-      for (const marker of markers) {
-        marker.setMap();
+      for (let i = 0; i < markers.length; i++) {
+        markers[i].setMap();
       }
       markers = [];
     }
@@ -156,9 +154,11 @@ const AccommodationMap = ({
     // 각 카테고리에 클릭 이벤트
     function addCategoryClickEvent() {
       const category = categoryRef.current!;
-      const children: any = category.children;
-      for (const child of children) {
-        child.onclick = onClickCategory;
+      const children: any = category!.children;
+      console.log(children, "children");
+      for (let i = 0; i < children.length; i++) {
+        // children[i].addEventListener("click", onClickCategory);
+        children[i].onclick = onClickCategory;
       }
     }
     function onClickCategory(this: HTMLElement, event: any) {
@@ -181,8 +181,8 @@ const AccommodationMap = ({
     function changeCategoryClass(el: { className: string } | null) {
       const category = categoryRef.current!;
       const children = category!.children;
-      for (const child of children) {
-        child.className = "";
+      for (let i = 0; i < children.length; i++) {
+        children[i].className = "";
       }
 
       if (el) {
@@ -193,7 +193,7 @@ const AccommodationMap = ({
     customOverlay.setMap(map);
     placeOverlay.setMap(map);
     marker.setMap(map);
-  }, [window.kakao]);
+  }, []);
 
   return (
     <div className="accommodation__map">

--- a/src/pages/home/detailFilter/DetailCategoryModal.tsx
+++ b/src/pages/home/detailFilter/DetailCategoryModal.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useQueryClient } from "react-query";
-import { useSetRecoilState, useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { detailState } from "@/states/detailState";
 import { commitOptions } from "./detailCommitFnc";
 import TermsAgreementItem from "@/components/termsAgreementItem/TermsAgreementItem";
@@ -8,6 +7,7 @@ import { IoClose } from "react-icons/io5";
 
 import "./detailCategoryModal.scss";
 import { Button } from "@/components/common";
+import { responseState } from "@/states/responseState";
 
 export interface OptionI {
   key: string;
@@ -33,7 +33,9 @@ const filterOption = {
 };
 
 const DetailCategoryModal = (props: detailProps) => {
-  const queryClient = useQueryClient();
+  // const queryClient = useQueryClient();
+  const [responseStates] = useRecoilState(responseState);
+  // responseArray
   const [detail] = useRecoilState(detailState);
   const setFilteredAtom = useSetRecoilState(detailState);
   const setOpenDetail = props.setOpenDetail;
@@ -90,7 +92,7 @@ const DetailCategoryModal = (props: detailProps) => {
     commitOptions(
       activeTab,
       options,
-      queryClient,
+      responseStates,
       setFilteredAtom,
       setOpenDetail
     );

--- a/src/pages/home/detailFilter/DetailCategoryModal.tsx
+++ b/src/pages/home/detailFilter/DetailCategoryModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import { detailState } from "@/states/detailState";
 import { commitOptions } from "./detailCommitFnc";
@@ -34,13 +34,8 @@ const filterOption = {
 
 const DetailCategoryModal = (props: detailProps) => {
   const [responseStates] = useRecoilState(responseState);
-  const [detail] = useRecoilState(detailState);
   const setFilteredAtom = useSetRecoilState(detailState);
   const setOpenDetail = props.setOpenDetail;
-
-  useEffect(() => {
-    console.log(detail);
-  }, [detail]);
 
   const [activeTab, setActiveTab] = useState<number>(0);
   const [options, setOptions] = useState<OptionI[]>([
@@ -90,7 +85,7 @@ const DetailCategoryModal = (props: detailProps) => {
     commitOptions(
       activeTab,
       options,
-      responseStates,
+      responseStates.responseArray,
       setFilteredAtom,
       setOpenDetail
     );

--- a/src/pages/home/detailFilter/DetailCategoryModal.tsx
+++ b/src/pages/home/detailFilter/DetailCategoryModal.tsx
@@ -33,9 +33,7 @@ const filterOption = {
 };
 
 const DetailCategoryModal = (props: detailProps) => {
-  // const queryClient = useQueryClient();
   const [responseStates] = useRecoilState(responseState);
-  // responseArray
   const [detail] = useRecoilState(detailState);
   const setFilteredAtom = useSetRecoilState(detailState);
   const setOpenDetail = props.setOpenDetail;

--- a/src/pages/home/detailFilter/detailCommitFnc.ts
+++ b/src/pages/home/detailFilter/detailCommitFnc.ts
@@ -1,4 +1,3 @@
-import { responseStateTypes } from "./../../../states/responseState";
 import { OptionI } from "./DetailCategoryModal";
 import { Accommodation } from "@/states/detailState";
 

--- a/src/pages/home/detailFilter/detailCommitFnc.ts
+++ b/src/pages/home/detailFilter/detailCommitFnc.ts
@@ -1,17 +1,16 @@
-import { QueryClient } from "react-query";
+import { responseStateTypes } from "./../../../states/responseState";
 import { OptionI } from "./DetailCategoryModal";
 import { Accommodation } from "@/states/detailState";
 
 export const commitOptions = (
   activeTab: number,
   options: OptionI[],
-  queryClient: QueryClient,
+  responseStates: any,
   setFilteredAtom: React.Dispatch<React.SetStateAction<Accommodation[]>>,
   setOpenDetail: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
   const selectedOptions = options.filter(option => option.state);
-  const cachedMainData: any = queryClient.getQueryData(["accommodations"]);
-  const cachedData = cachedMainData.data.accommodations;
+  const cachedData = responseStates.responseArray;
 
   if (cachedData) {
     let sortedData;

--- a/src/pages/home/home.scss
+++ b/src/pages/home/home.scss
@@ -11,10 +11,13 @@
 }
 
 .home-inner {
-  display: flex;
-  width: rem(1192);
+  max-width: rem(1192);
+  width: 100%;
   height: 100%;
+
+  display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: rem(24);
   overflow-y: scroll;
   padding-bottom: rem(120);


### PR DESCRIPTION
페이지
헤더, 필터, 메인페이지 ~900px까지는 반응형 대응

✨ 작업 내용
<img width="970" alt="image" src="https://github.com/FC-FastCatch/FastCatch-FrontEnd/assets/126222848/b8b1f51b-698f-4a6f-922d-0f9acce5d5eb">

헤더, 필터, 메인페이지 ~900px까지는 반응형 대응
- 헤더 1200px 이하에서 좌우 padding 20px 주기
- 1200px이하에서 헤더 가운데 필터 영역과 우측 장바구니 버튼이 겹치는 현상 수정
  - 사용자 이름 display: none으로 바꾸거나 필터를 좌측정렬도 바꾸어서 공간 확보
- 필터 1200px 이하에서 좌우 padding 20px 주기
- 메인페이지 아이템 flexbox wrap되게 수정

이 모든건 900px까지만 보장하였습니다. 900이하에선 레이아웃 고정. 그냥 짤림.