### PR TITLE
[#112] 로그아웃, 재발급 토큰 서버연결

### DIFF
--- a/src/api/instanceApi.ts
+++ b/src/api/instanceApi.ts
@@ -1,5 +1,8 @@
 import axios, { AxiosInstance } from "axios";
-import { getToken } from "../utils/getToken";
+
+import { refreshAccessToken } from "@/hooks/useAuth";
+import { isAccessTokenExpired } from "@/utils/checkToken";
+import { getToken } from "@/utils/getToken";
 
 const instance: AxiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -7,13 +10,24 @@ const instance: AxiosInstance = axios.create({
 });
 
 instance.interceptors.request.use(
-  config => {
+  async (config) => {
     config.headers["Content-Type"] = "application/json";
     const accessToken = getToken();
     if (accessToken) {
-      config.headers["Authorization"] = `Bearer ${accessToken}`;
+      const isTokenExpired = isAccessTokenExpired(accessToken);
+
+      if (isTokenExpired) {
+        try {
+          const newAccessToken = await refreshAccessToken();
+          config.headers["Authorization"] = `Bearer ${newAccessToken}`;
+        } catch (refreshError) {
+          console.error('accessToken 재발급 실패', refreshError);
+        }
+      } else {
+        config.headers["Authorization"] = `Bearer ${accessToken}`;
+      }
     }
-    https: return config;
+    return config;
   },
   error => {
     return Promise.reject(error);
@@ -21,10 +35,14 @@ instance.interceptors.request.use(
 );
 
 instance.interceptors.response.use(
-  response => {
-    return response;
-  },
-  async error => {
+  response => response,
+  error => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      alert('인증이 만료되어 재 로그인이 필요합니다.');
+      window.location.href = '/login';
+    }
     return Promise.reject(error);
   }
 );

--- a/src/api/instanceApi.ts
+++ b/src/api/instanceApi.ts
@@ -4,6 +4,7 @@ import { refreshAccessToken } from "@/hooks/useAuth";
 import { isAccessTokenExpired } from "@/utils/checkToken";
 import { getToken } from "@/utils/getToken";
 
+
 const instance: AxiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 5000,
@@ -13,6 +14,7 @@ instance.interceptors.request.use(
   async (config) => {
     config.headers["Content-Type"] = "application/json";
     const accessToken = getToken();
+
     if (accessToken) {
       const isTokenExpired = isAccessTokenExpired(accessToken);
 

--- a/src/components/common/header/logoutButton/LogoutButton.tsx
+++ b/src/components/common/header/logoutButton/LogoutButton.tsx
@@ -1,12 +1,21 @@
-import { MdLogout } from "react-icons/md";
-import "../cartButton/cartbutton.scss";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
 import { ModalLayout, ModalPortal } from "../..";
+import { MdLogout } from "react-icons/md";
+
+import { userState } from "@/states/userState";
+import instance from "@/api/instanceApi";
+import { getRefreshToken, getToken } from "@/utils/getToken";
+
+import "../cartButton/cartbutton.scss";
 
 const LogoutButton = () => {
   const [modalVisible, setModalVisible] = useState(false);
+  const setUserInfo = useSetRecoilState(userState);
   const navigate = useNavigate();
+  const accessToken = getToken();
+  const refreshToken = getRefreshToken();
 
   const modalProps = {
     title: "로그아웃",
@@ -17,9 +26,31 @@ const LogoutButton = () => {
         size: "small",
         colorName: "coral500",
         onClick: () => {
-          console.log("확인");
-          localStorage.removeItem("accessToken");
-          navigate("/");
+          
+          const logOut = async () => {
+            try {
+
+              const body = {
+                accessToken,
+                refreshToken
+              }
+          
+              const res = await instance.post(`/api/members/signout`, 
+                body
+              );
+          
+              localStorage.removeItem('accessToken');
+              localStorage.removeItem('refreshToken');
+              setUserInfo(null);
+              navigate('/');
+              
+              return res;
+            } catch (error) {
+              console.log(error);
+            }
+          };
+
+          logOut();
           setModalVisible(false);
         },
       },

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,0 +1,53 @@
+import axios from "axios";
+import { useSetRecoilState } from "recoil";
+
+import { userInfoI, userState } from "@/states/userState";
+
+export const useAuth = () => {
+
+  const setUserInfo = useSetRecoilState(userState);
+
+  const setToken = (
+    accessToken: string, refreshToken: string, memberRes: userInfoI
+  ) => {
+    localStorage.setItem("accessToken", accessToken);
+    localStorage.setItem("refreshToken", refreshToken);
+    setUserInfo(memberRes)
+  }
+  return {
+    setToken
+  }
+}
+
+export async function refreshAccessToken () {
+
+  const refreshToken = localStorage.getItem("refreshToken");
+  const userDataString = localStorage.getItem("userState");
+
+  if (!userDataString) {
+    console.error('User data not found in localStorage');
+    return
+  }
+
+  const userData = JSON.parse(userDataString);
+  const userEmail = userData.email;
+
+  const response = await axios.post(
+    `${import.meta.env.VITE_API_BASE_URL}/api/members/re-token`,
+    { email: userEmail },
+    {
+      headers: {
+        Authorization: `Bearer ${refreshToken}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  console.log('토큰 재발급 성공', response.data);
+  const newAccessToken = response.data.data.accessToken;
+  localStorage.setItem('accessToken', newAccessToken);
+
+  return newAccessToken;
+}
+
+

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -49,5 +49,3 @@ export async function refreshAccessToken () {
 
   return newAccessToken;
 }
-
-

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import router from "./routes/router.tsx";
 import { QueryClient, QueryClientProvider } from "react-query";
-// import { worker } from "./mocks/browsers.ts";
 import { RecoilRoot } from "recoil";
 
 const queryClient = new QueryClient();
@@ -12,7 +11,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
+          <RouterProvider router={router} />
       </QueryClientProvider>
     </RecoilRoot>
   </React.StrictMode>

--- a/src/pages/orderList/orderListItem/orderListItem.scss
+++ b/src/pages/orderList/orderListItem/orderListItem.scss
@@ -25,4 +25,7 @@
   &__swiper {
     margin-bottom: rem(8);
   }
+  &:last-of-type {
+    border-bottom: 0;
+  }
 }

--- a/src/pages/users/login/Login.tsx
+++ b/src/pages/users/login/Login.tsx
@@ -1,15 +1,15 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
-import { useSetRecoilState } from "recoil";
-import { userState } from "@/states/userState";
 
 import { FaRegEye } from "react-icons/fa";
 import { FaRegEyeSlash } from "react-icons/fa";
 
 import "../users.scss";
 import instance from "@/api/instanceApi";
+import { useAuth } from "@/hooks/useAuth";
 import { Button, ToastLayout } from "@/components/common";
+import { memberResI } from "@/types/member";
 
 const Login = () => {
   // 회원가입/로그인 링크이동
@@ -32,19 +32,18 @@ const Login = () => {
   } = useForm<loginData>({
     mode: "onBlur",
   });
-  const setUserInfo = useSetRecoilState(userState);
   const { showToast, ToastContainer } = ToastLayout();
   const email = watch("email");
   const password = watch("password");
+  const { setToken } = useAuth();
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const requestBody = { email, password };
     try {
       const res = await instance.post("/api/members/signin", requestBody);
-      const { accessToken, memberResponse }: memberResI = res.data.data;
-      localStorage.setItem("accessToken", accessToken);
-      setUserInfo(memberResponse);
+      const { accessToken, refreshToken, memberResponse }: memberResI = res.data.data;      
+      setToken( accessToken, refreshToken, memberResponse );
       navigate("/");
     } catch (error) {
       showToast({
@@ -136,20 +135,4 @@ export default Login;
 interface loginData {
   email: string;
   password: string;
-}
-
-interface memberInfoI {
-  id: number;
-  email: string;
-  name: string;
-  nickname: string;
-  birthday: string;
-  phoneNumber: string;
-  cartId: number;
-}
-
-interface memberResI {
-  accessToken: string;
-  refreshToken: string;
-  memberResponse: memberInfoI;
 }

--- a/src/pages/users/signup/Signup.tsx
+++ b/src/pages/users/signup/Signup.tsx
@@ -93,6 +93,8 @@ const Signup = () => {
     nickname.length >= 2 &&
     nickname.length <= 14;
 
+  const currentYear = new Date().getFullYear();
+
   return (
     <>
     <div className="common-bg"></div>
@@ -193,7 +195,7 @@ const Signup = () => {
                     {...register("birthday", {
                       required: "생년월일을 입력하세요",
                       pattern: {
-                        value: /^\d{4}-\d{2}-\d{2}$/,
+                        value: /^(19\d\d|20\d\d)-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/,
                         message:
                           "올바른 형식의 생년월일을 입력하세요 (yyyy-mm-dd)",
                       },

--- a/src/pages/users/signup/Signup.tsx
+++ b/src/pages/users/signup/Signup.tsx
@@ -6,10 +6,10 @@ import { FaRegEye } from "react-icons/fa";
 import { FaRegEyeSlash } from "react-icons/fa";
 
 import TermsAgreement from "@/components/termsAgreement/TermsAgreement";
-
-import "../users.scss";
 import instance from "@/api/instanceApi";
 import { Button, ToastLayout } from "@/components/common";
+
+import "../users.scss";
 
 const Signup = () => {
   // 회원가입/로그인 링크이동
@@ -92,8 +92,6 @@ const Signup = () => {
     /^[A-Za-z가-힣]+$/.test(nickname) &&
     nickname.length >= 2 &&
     nickname.length <= 14;
-
-  const currentYear = new Date().getFullYear();
 
   return (
     <>

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -1,0 +1,15 @@
+interface memberInfoI {
+  id: number;
+  email: string;
+  name: string;
+  nickname: string;
+  birthday: string;
+  phoneNumber: string;
+  cartId: number;
+}
+
+export interface memberResI {
+  accessToken: string;
+  refreshToken: string;
+  memberResponse: memberInfoI;
+}

--- a/src/utils/checkToken.ts
+++ b/src/utils/checkToken.ts
@@ -1,0 +1,20 @@
+export function isAccessTokenExpired(accessToken: string) {
+  if (!accessToken) {
+    return true;
+  }
+
+  const decodedToken = decodeAccessToken(accessToken);
+  const currentTime = Math.floor(Date.now() / 1000);
+
+  return decodedToken.exp < currentTime;
+}
+
+function decodeAccessToken(accessToken: string) {
+  // Decode the JWT token to get its payload
+  const tokenParts = accessToken.split('.');
+  const encodedPayload = tokenParts[1];
+  const decodedPayload = atob(encodedPayload);
+
+  // Parse the JSON payload
+  return JSON.parse(decodedPayload);
+}

--- a/src/utils/checkToken.ts
+++ b/src/utils/checkToken.ts
@@ -10,11 +10,10 @@ export function isAccessTokenExpired(accessToken: string) {
 }
 
 function decodeAccessToken(accessToken: string) {
-  // Decode the JWT token to get its payload
+
   const tokenParts = accessToken.split('.');
   const encodedPayload = tokenParts[1];
   const decodedPayload = atob(encodedPayload);
-
-  // Parse the JSON payload
+  
   return JSON.parse(decodedPayload);
 }

--- a/src/utils/getToken.ts
+++ b/src/utils/getToken.ts
@@ -10,3 +10,16 @@ export const getToken = () => {
     return null;
   }
 };
+
+export const getRefreshToken = () => {
+  try {
+    const token = localStorage.getItem("refreshToken");
+    if (token) {
+      return token;
+    } else {
+      return null;
+    }
+  } catch (error) {
+    return null;
+  }
+}


### PR DESCRIPTION
## 페이지
로그인페이지

## ✨ 작업 내용
- instance 에 token 만료시 재발급 요청
- 로그아웃 api 요청 및 localStorage 에서 토큰 삭제
- refresh 토큰 만료시 재로그인 유도
- 회원가입시 생년월일 유효성 검사 수정
- 주문목록에서 마지막 요소 border와 버튼이 닿아있어서, border-bottom:0 으로 수정했습니다!

## 📸 스크린샷

📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
아래 글이 로그인 구현의 전반적인 내용을 이해하는데 도움이 많이 되었습니다
https://velog.io/@yaytomato/%ED%94%84%EB%A1%A0%ED%8A%B8%EC%97%90%EC%84%9C-%EC%95%88%EC%A0%84%ED%95%98%EA%B2%8C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0

리프레시 토큰을 쿠키에 담아서 핸들링 시도했다가
react-cookie 훅 사용하는 부분에서 여러 오류를 접해서,,
추후에 다시 시도해 볼 예정입니다!

close https://github.com/FC-FastCatch/FastCatch-FrontEnd/issues/112